### PR TITLE
Bump activejob dependency version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@
 
 language: ruby
 rvm:
+  - 2.4.0
   - 2.2.2
-  - 2.1.5
-  - 2.0.0
-  - 1.9.3
-  - 1.9.2
-  - jruby-19mode
+services:
+  - redis-server

--- a/active_job_lock.gemspec
+++ b/active_job_lock.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob('lib/**/*')
   s.files            += Dir.glob('test/**/*')
 
-  s.add_dependency('activejob', '~> 4.2.0')
-  s.add_dependency('redis', '~>3.2')
+  s.add_dependency('activejob', '< 6.0')
+  s.add_dependency('redis', '~> 3.2')
   s.add_development_dependency('rake', '~> 10.3')
-  s.add_development_dependency('minitest', '~> 5.2')
+  s.add_development_dependency('minitest', '~> 5.8.4')
   s.add_development_dependency('yard', '~> 0.8')
 
   s.description       = <<desc


### PR DESCRIPTION
Allow this gem to work with Rails 5.

Note, Rails 5 requires Ruby version 2.2.2 or higher.